### PR TITLE
Alphabetically sorted interests

### DIFF
--- a/penpals-frontend/src/components/SidePanel.tsx
+++ b/penpals-frontend/src/components/SidePanel.tsx
@@ -212,6 +212,17 @@ export default function SidePanel({
   const [editingAccountLocation, setEditingAccountLocation] = useState(false);
 
   const allInterests = [...AVAILABLE_SUBJECTS];
+  const sortedInterests = useMemo(() => {
+    return [...allInterests].sort((a, b) => {
+      const aChecked = currentAccount.interests.includes(a);
+      const bChecked = currentAccount.interests.includes(b);
+      if (aChecked !== bChecked) return aChecked ? -1 : 1;
+      return a.localeCompare(b);
+    });
+  }, [allInterests, currentAccount.interests]);
+  const sortedSelectedInterests = useMemo(() => {
+    return [...currentAccount.interests].sort((a, b) => a.localeCompare(b));
+  }, [currentAccount.interests]);
 
   const toggleInterest = (interest: string) => {
     const newInterests = currentAccount.interests.includes(interest)
@@ -836,7 +847,7 @@ export default function SidePanel({
 
                     <ScrollArea className="h-64">
                       <div className="space-y-3 pr-4">
-                        {allInterests.map((subject) => (
+                        {sortedInterests.map((subject) => (
                           <div key={subject} className="flex items-center space-x-2">
                             <Checkbox
                               id={subject}
@@ -873,7 +884,7 @@ export default function SidePanel({
 
                     {currentAccount.interests.length > 0 && (
                       <div className="flex flex-wrap gap-2 pt-2 border-t border-slate-200 dark:border-slate-700">
-                        {currentAccount.interests.map((interest) => (
+                        {sortedSelectedInterests.map((interest) => (
                           <Badge key={interest} variant="secondary" className="bg-blue-600 text-white">
                             {interest}
                           </Badge>


### PR DESCRIPTION
<insert number below>
Resolves #22 
  
## 

## Description
<At least a sentence or two> 
Interests are now sorted by ticked/unticked, and then alphabetically.

## Checklist
<Type x in place of the space bar to tick each one off> 

- [x] I have verified that my change compiles properly.
- [x] I have ensured that the changes are formatted correctly.
- [x] I have checked that this change does not create additional warnings.
- [x] I have assigned MYSELF to the PR and added any relevant labels.

## Next steps
<State whether this is the end or if there is a continuation via a new issue>
May need a further look if we migrate from hard-coded to network added.
Currently, adding an interest does **not** add it to the list. This must be fixed together with above in issue #53 
