### PR TITLE
Password hashing and verification on frontend

### DIFF
--- a/penpals-frontend/package.json
+++ b/penpals-frontend/package.json
@@ -31,6 +31,7 @@
             "@radix-ui/react-tooltip": "^1.1.8",
             "@radix-ui/react-visually-hidden": "^1.1.1",
             "@types/leaflet": "^1.9.21",
+            "bcryptjs": "^3.0.3",
             "class-variance-authority": "^0.7.1",
             "clsx": "*",
             "cmdk": "^1.1.1",
@@ -48,6 +49,7 @@
             "recharts": "^2.15.2",
             "sonner": "^2.0.3",
             "tailwind-merge": "*",
+            "tz-lookup": "^6.1.25",
             "vaul": "^1.1.2"
       },
       "devDependencies": {

--- a/penpals-frontend/src/components/LocationAutocomplete.tsx
+++ b/penpals-frontend/src/components/LocationAutocomplete.tsx
@@ -50,6 +50,11 @@ export default function LocationAutocomplete({
 
     if (query.length >= 3) {
       debounceRef.current = window.setTimeout(async () => {
+        // Don't search if a location is already selected and query matches
+        if (value && query === value.name) {
+          return;
+        }
+        
         setIsLoading(true);
         try {
           const results = await LocationService.searchLocations(query);
@@ -73,7 +78,7 @@ export default function LocationAutocomplete({
         clearTimeout(debounceRef.current);
       }
     };
-  }, [query]);
+  }, [query, value]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newQuery = e.target.value;
@@ -87,8 +92,16 @@ export default function LocationAutocomplete({
 
   const handleSuggestionClick = (suggestion: LocationSuggestion) => {
     const location = LocationService.suggestionToLocation(suggestion);
+    
+    // Clear any pending debounced search
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = undefined;
+    }
+    
     setQuery(location.name);
     onChange(location);
+    setSuggestions([]);
     setShowSuggestions(false);
     setSelectedIndex(-1);
   };
@@ -124,7 +137,8 @@ export default function LocationAutocomplete({
   };
 
   const handleFocus = () => {
-    if (suggestions.length > 0) {
+    // Only show suggestions if there are any and no location is selected
+    if (suggestions.length > 0 && (!value || query !== value.name)) {
       setShowSuggestions(true);
     }
   };


### PR DESCRIPTION
<insert number below>
Resolves #68 
  
## 

## Description
<At least a sentence or two> 
Frontend now hashes password plaintext, on top of hashing done on backend.

Modified `init_db.py` to do the same hashing on new frontend so that logging onto dummy accounts work.

Creating an account now requires password verification.

Also changed it so that `init_db.py` and `main.py` both have the same `penpals_db` path, avoiding duplicate instances. 


## Checklist
<Type x in place of the space bar to tick each one off> 

- [x] I have verified that my change compiles properly.
- [x] I have ensured that the changes are formatted correctly.
- [x] I have checked that this change does not create additional warnings.
- [x] I have assigned MYSELF to the PR and added any relevant labels.

## Next steps
<State whether this is the end or if there is a continuation via a new issue>
No further action needed for the time being.
